### PR TITLE
replace the url of the logo of search1api plugin

### DIFF
--- a/src/search1api.json
+++ b/src/search1api.json
@@ -5,7 +5,7 @@
   "identifier": "search1api",
   "manifest": "https://lobehub.search1api.com/manifest.json",
   "meta": {
-    "avatar": "https://cdn.discordapp.com/attachments/1109354586604585011/1236568039198167050/favicon.webp?ex=66387b3a&is=663729ba&hm=38435c611569cf1895bd89a0181c0cb09de2f5d659a4e913c4a51c5ca22e7131&",
+    "avatar": "https://i.postimg.cc/fRtTXTvC/favicon.webp",
     "tags": ["web", "search"],
     "title": "Search1API",
     "description": "Search aggregation service, specifically designed for LLMs"


### PR DESCRIPTION
#### 📝 信息 | Information

Sorry for that, the old url is invalid now, I need to replace it to a new one

<img width="807" alt="image" src="https://github.com/lobehub/lobe-chat-plugins/assets/134143178/8cbba8ec-22da-48a7-b4cb-34bed195d22b">


#### ✅ 检查列表 | Checklist:

<!--- Checkboxes will become clickable after submit, no need to fill them now --->

- [x] 我已阅读了 [`Readme.md`](https://github.com/lobehub/lobe-chat-plugins/)
- [x] 描述是用英文编写的。
- [x] `meta.json` 和 `plugin-template.json` 没有被修改过。
- [x] `entry` 放置在 `src` 目录中，并且使用 `.json` 文件扩展名。

---

- [x] I have read the [`Readme.md`](https://github.com/lobehub/lobe-chat-plugins/)
- [x] The description is written in English.
- [x] The `meta.json` and `plugin-template.json` have not been modified.
- [x] The `entry` is placed in the `src` directory with the `.json` file extension.
