### PR TITLE
Add Apollo Proxy Plugin

### DIFF
--- a/src/apollo-proxy.json
+++ b/src/apollo-proxy.json
@@ -1,0 +1,14 @@
+{
+  "author": "Apollo Intelligence Network",
+  "identifier": "apollo-proxy",
+  "homepage": "https://apolloai.team",
+  "manifest": "https://apolloai.team/.well-known/mcp",
+  "meta": {
+    "title": "Apollo Proxy",
+    "description": "Fetch any URL through residential proxies (190+ countries). Pay-per-use via x402 micropayments.",
+    "avatar": "🌐",
+    "tags": ["proxy", "web-scraping", "x402", "micropayments"],
+    "category": "tools"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
**Plugin:** Apollo Proxy

Fetch any URL through residential proxies (190+ countries) with pay-per-use x402 micropayments (USDC on Base).

**Features:**
- Residential proxy access (190+ exit countries)
- x402 micropayment protocol integration
- /bin/bash.005/request pricing
- 250KB max response
- Rate limited to 100 req/min

**Homepage:** https://apolloai.team
**Author:** Apollo Intelligence Network

**Tags:** proxy, web-scraping, x402, micropayments

## Summary by Sourcery

New Features:
- Introduce an Apollo Proxy plugin that enables residential proxy access across 190+ countries with x402 micropayment integration.