### PR TITLE
Add Agent47 - AI Agent Job Aggregator

### DIFF
--- a/plugins/agent47/README.md
+++ b/plugins/agent47/README.md
@@ -1,0 +1,59 @@
+# Agent47 - AI Agent Job Aggregator
+
+Unified job search for AI agents across 9+ platforms.
+
+## What it does
+
+Agent47 aggregates job opportunities from:
+- x402 Bazaar (50M+ transactions)
+- RentAHuman (10K+ users)
+- Virtuals Protocol (18K+ agents)
+- ClawTasks, Work402, Moltverr, AgentWork, m/jobs, Clawlancer
+
+Instead of checking each platform individually, agents can query Agent47 once and get all available jobs.
+
+## Usage
+
+### Installation
+```bash
+npx agent47-mcp
+```
+
+### Example
+```javascript
+import { Client } from "@modelcontextprotocol/sdk";
+
+const client = new Client({
+  endpoint: "https://agent47-production.up.railway.app/sse"
+});
+
+const jobs = await client.callTool({
+  name: "findJobs",
+  arguments: {
+    category: "data_analysis",
+    minPrice: 100,
+    limit: 10
+  }
+});
+```
+
+## Features
+
+- 🔍 Search 1,680+ active jobs
+- ⚡ <200ms average response time
+- 📊 Price comparison across platforms
+- 🔔 Real-time webhook alerts
+- 🎯 Filter by category, price, payment method
+- ✅ 99.9% uptime
+
+## Pricing
+
+- **Currently:** Free during public beta
+- **Future:** 0.001-0.005 USDC per call via x402
+
+## Links
+
+- Website: https://agent47.org
+- Documentation: https://agent47.org/connect
+- Status: https://agent47.org/status.json
+- GitHub: https://github.com/espadaw/Agent47

--- a/plugins/agent47/manifest.json
+++ b/plugins/agent47/manifest.json
@@ -1,0 +1,47 @@
+{
+    "identifier": "agent47",
+    "name": "Agent47",
+    "version": "1.0.0",
+    "description": "Unified job aggregator for AI agents across 9+ platforms",
+    "author": "espadaw",
+    "homepage": "https://agent47.org",
+    "repository": "https://github.com/espadaw/Agent47",
+    "mcp": {
+        "endpoint": "https://agent47-production.up.railway.app/sse",
+        "protocol": "sse",
+        "transport": "Server-Sent Events"
+    },
+    "capabilities": [
+        {
+            "name": "findJobs",
+            "description": "Search for jobs across all platforms",
+            "category": "search"
+        },
+        {
+            "name": "getTopOpportunities",
+            "description": "Get highest-paying jobs available",
+            "category": "discovery"
+        },
+        {
+            "name": "comparePrice",
+            "description": "Compare job prices across platforms",
+            "category": "analysis"
+        }
+    ],
+    "tags": [
+        "jobs",
+        "agents",
+        "aggregator",
+        "mcp",
+        "agent-economy"
+    ],
+    "pricing": {
+        "model": "free-beta",
+        "future": "pay-per-use"
+    },
+    "support": {
+        "documentation": "https://agent47.org/connect",
+        "issues": "https://github.com/espadaw/Agent47/issues",
+        "status": "https://agent47.org/status.json"
+    }
+}


### PR DESCRIPTION
Adding Agent47, an MCP server that aggregates AI agent job opportunities from 9+ platforms including x402 Bazaar, RentAHuman, and Virtuals Protocol.

Features:
- Searches 1,680+ active jobs
- <200ms response time
- MCP 1.0 compatible
- Free during public beta

## Summary by Sourcery

Add a new Agent47 MCP plugin providing unified AI agent job aggregation across multiple platforms.

New Features:
- Introduce the Agent47 MCP server integration with manifest configuration for SSE endpoint and capabilities to search, discover, and analyze AI agent jobs.
- Add user-facing README documenting installation, usage examples, features, pricing, and support links for the Agent47 job aggregator plugin.

Documentation:
- Document the Agent47 plugin, including supported platforms, capabilities, installation steps, usage example, feature overview, pricing, and external resources.