### PR TITLE
Add CrossFin MCP — Asian crypto market data

### DIFF
--- a/src/crossfin-mcp.json
+++ b/src/crossfin-mcp.json
@@ -1,0 +1,14 @@
+{
+  "author": "bubilife1202",
+  "createdAt": "2026-02-20",
+  "homepage": "https://crossfin.dev",
+  "identifier": "crossfin-mcp",
+  "meta": {
+    "avatar": "https://crossfin.dev/favicon.ico",
+    "description": "AI agent access to Asian crypto markets. Korean exchange routing, kimchi premium monitoring, and x402 paid APIs across 9 exchanges.",
+    "tags": ["crypto", "finance", "korea", "mcp", "x402"],
+    "title": "CrossFin",
+    "category": "stocks-finance"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
Adds CrossFin MCP server for AI agent access to Asian crypto markets.

- Real-time Korean exchange data (Bithumb, Upbit, Coinone, GoPax)
- Cross-exchange routing across 9 exchanges
- Kimchi premium monitoring
- x402 USDC payment-enabled APIs

**Install:** `npx -y crossfin-mcp`
**Homepage:** https://crossfin.dev
**npm:** https://www.npmjs.com/package/crossfin-mcp

## Summary by Sourcery

New Features:
- Introduce CrossFin MCP configuration to enable AI agent access to Asian crypto market data.