### PR TITLE
Add Philidor DeFi Vault Risk Analytics MCP

### DIFF
--- a/src/philidor-defi-vault-risk-analytics.json
+++ b/src/philidor-defi-vault-risk-analytics.json
@@ -4,7 +4,7 @@
   "homepage": "https://philidor.io",
   "identifier": "philidor-defi-vault-risk-analytics",
   "meta": {
-    "avatar": "https://philidor.io/icon.png",
+    "avatar": "https://analytics.philidor.io/philidor_logo.png",
     "description": "Search and analyze 700+ DeFi vaults across Morpho, Aave, Spark, Yearn, Beefy, Compound, and Uniswap. Multi-vector risk scoring with Prime/Core/Edge tier classification. No API key needed.",
     "tags": ["defi", "risk", "vaults", "ethereum", "crypto", "yield"],
     "title": "Philidor DeFi Vault Risk Analytics",


### PR DESCRIPTION
Adds **Philidor DeFi Vault Risk Analytics** — an MCP server for AI agent access to institutional-grade DeFi vault risk data.

## What it does

- Search and analyze **700+ DeFi vaults** across Morpho, Aave, Spark, Yearn, Beefy, Compound, and Uniswap
- Multi-vector **risk scoring** (Asset Composition, Platform & Strategy, Governance) with **Prime/Core/Edge** tier classification
- Compare vaults side-by-side on TVL, APR, risk score, and audit status
- Find safest vaults filtered by asset, chain, or minimum TVL
- Protocol and curator intelligence
- Incident monitoring (vaults with recent critical events)
- **No API key needed** — fully open, free to use

## Server details

- **MCP Endpoint:** `https://mcp.philidor.io/api/mcp`
- **Transport:** Streamable HTTP
- **Homepage:** https://philidor.io
- **GitHub:** https://github.com/Philidor-Labs/philidor-mcp
- **License:** MIT

## Category

`stocks-finance` — DeFi risk analytics and vault intelligence.

## Summary by Sourcery

Add a new MCP server configuration for Philidor DeFi Vault Risk Analytics, exposing institutional-grade DeFi vault risk and vault intelligence data under the stocks-finance category.