### PR TITLE
feat: add Xquik MCP server

### DIFF
--- a/src/xquik-mcp.json
+++ b/src/xquik-mcp.json
@@ -1,0 +1,14 @@
+{
+  "author": "Xquik",
+  "createdAt": "2026-02-28",
+  "homepage": "https://xquik.com/mcp",
+  "identifier": "xquik-mcp",
+  "meta": {
+    "avatar": "https://raw.githubusercontent.com/Xquik-dev/x-twitter-scraper/master/logo.png",
+    "description": "Real-time X (Twitter) data platform with 22 MCP tools. Monitor accounts, run giveaway draws, extract followers, replies, quotes, and more.",
+    "tags": ["twitter", "x", "social-media", "monitoring", "data-extraction", "mcp"],
+    "title": "Xquik",
+    "category": "social"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
Adds **Xquik** - a real-time X (Twitter) data platform MCP server with 22 tools.

## What it does

- **Monitor** X accounts for new tweets, replies, retweets, quotes, and follower changes in real time
- **Run giveaway draws** from tweet replies with configurable filters (must retweet, min followers, account age, required hashtags/keywords)
- **Extract bulk data**: followers, following, verified followers, replies, reposts, quotes, threads, mentions, posts, community members, list members, and more (19 extraction tools)
- **Search tweets** and **look up profiles** with full engagement metrics
- **Get trending topics** by region

## Server details

- **Homepage:** https://xquik.com/mcp
- **Transport:** Streamable HTTP (port 3100, API key auth)
- **Tools:** 22 MCP tools

## Category

`social` - X (Twitter) data extraction, monitoring, and giveaway draws.

## Summary by Sourcery

New Features:
- Add configuration for an Xquik MCP server that exposes multiple X (Twitter) data extraction and monitoring tools, including giveaway draw capabilities.
