### PR TITLE
feat: add BotIndex — Crypto market intelligence with predictive signals

### DIFF
--- a/src/BotIndex.json
+++ b/src/BotIndex.json
@@ -1,0 +1,14 @@
+{
+  "author": "Cyberweasel777",
+  "homepage": "https://github.com/Cyberweasel777/King-Backend",
+  "identifier": "BotIndex",
+  "manifest": "https://king-backend.fly.dev/.well-known/ai-plugin.json",
+  "meta": {
+    "avatar": "🤖",
+    "tags": ["crypto", "sports-betting", "trading", "x402", "mcp", "ai-agent", "defi"],
+    "title": "BotIndex",
+    "description": "AI-native signal intelligence API — sports odds, crypto correlations, token graduations, DFS optimization, and arbitrage detection. 50 free requests per wallet, then pay-per-request with USDC via x402. No API keys.",
+    "category": "stocks-finance"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## BotIndex MCP Server

**Crypto market intelligence** — predictive signals, whale divergence, convergence scoring.

Not another data feed. A convergence engine that synthesizes whale positions, developer activity, and behavioral demand into actionable intelligence with a [verifiable track record](https://api.botindex.dev/api/botindex/sentinel/track-record).

### Key Signals
- Convergence Scoring (multi-source synthesis)
- Whale Divergence Detection (Hyperliquid)
- Network Intelligence (ecosystem development velocity)
- Predictive Signals (DeepSeek-synthesized, verified accuracy)
- Query Surge Intelligence (what 19K+ daily consumers search for)
- Risk Radar (composite market regime scoring)

### Install
```bash
npx -y botindex-mcp
```

### Links
- https://botindex.dev
- https://npmjs.com/package/botindex-mcp-server
- https://github.com/Cyberweasel777/King-Backend