### PR TITLE
Add Sigil Notary plugin — cryptographic audit trails for AI agents

### DIFF
--- a/src/sigil-notary.json
+++ b/src/sigil-notary.json
@@ -1,0 +1,16 @@
+{
+  "author": "Chadd Harrison",
+  "createdAt": "2026-03-09",
+  "homepage": "https://github.com/sly-the-fox/sigil",
+  "identifier": "sigil-notary",
+  "locale": "en-US",
+  "manifest": "https://sigil-notary.dev/manifest.json",
+  "meta": {
+    "avatar": "🔏",
+    "tags": ["security", "audit", "trust", "mcp", "agent", "cryptography"],
+    "title": "Sigil Notary",
+    "description": "Tamper-evident, hash-chained audit trails for AI agents with Ed25519 signatures",
+    "category": "tools"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## What

Adds Sigil Notary as a plugin — tamper-evident, hash-chained audit trails for AI agents with Ed25519 signatures.

- **Name:** Sigil Notary
- **Author:** Chadd Harrison
- **Homepage:** https://github.com/sly-the-fox/sigil
- **PyPI:** https://pypi.org/project/sigil-notary/
- **License:** MIT
- **Tags:** security, audit, trust, mcp, agent, cryptography

Ships as an MCP server (`uvx sigil-notary`) with 3 tools: `attest_action`, `verify_receipt`, `get_chain`.

## Summary by Sourcery

New Features:
- Introduce the Sigil Notary plugin definition as a new MCP server integration with tools for attestation, verification, and chain inspection.