### PR TITLE
feat: add Polaris News Intelligence MCP server

### DIFF
--- a/src/polaris-news.json
+++ b/src/polaris-news.json
@@ -1,0 +1,16 @@
+{
+  "author": "The Polaris Report",
+  "createdAt": "2026-03-14",
+  "homepage": "https://thepolarisreport.com",
+  "identifier": "polaris-news",
+  "locale": "en-US",
+  "manifest": "https://api.thepolarisreport.com/api/v1/mcp",
+  "meta": {
+    "avatar": "🌐",
+    "tags": ["news", "search", "intelligence", "mcp", "research", "briefs"],
+    "title": "Polaris News Intelligence",
+    "description": "Verified, bias-scored intelligence briefs from a global news network. 8 MCP tools for search, feed, extraction, entity tracking, trend analysis, source comparison, and deep research.",
+    "category": "web-search"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## Polaris News Intelligence

**Type:** Remote MCP Server (Streamable HTTP)  
**Tools:** 8  
**Auth:** API key via `Authorization: Bearer` header or `?key=` query param  
**Endpoint:** `https://api.thepolarisreport.com/api/v1/mcp`

### Tools

| Tool | Description |
|------|-------------|
| `polaris_search` | Search verified news briefs by topic |
| `polaris_feed` | Get latest briefs, filter by category or source |
| `polaris_brief` | Full brief details by ID |
| `polaris_extract` | Extract article content from URLs |
| `polaris_entities` | Briefs mentioning a specific entity |
| `polaris_trending` | Trending entities by mention count |
| `polaris_compare` | Compare source coverage and bias on a topic |
| `polaris_research` | Deep research with key findings and entity map |

### Links

- Homepage: https://thepolarisreport.com
- API Docs: https://thepolarisreport.com/docs
- GitHub: https://github.com/JohnnyTarrr/polaris-sdks

## Summary by Sourcery

New Features:
- Introduce a new remote MCP server integration for Polaris News Intelligence with multiple news intelligence tools exposed.