### PR TITLE
feat: add Novyx MCP — persistent memory for AI agents (64 tools)

### DIFF
--- a/src/novyx-mcp.json
+++ b/src/novyx-mcp.json
@@ -1,0 +1,14 @@
+{
+  "author": "Novyx Labs",
+  "createdAt": "2026-03-19",
+  "homepage": "https://novyxlabs.com",
+  "identifier": "novyx-mcp",
+  "meta": {
+    "avatar": "https://raw.githubusercontent.com/novyxlabs/novyx-mcp/main/icon.png",
+    "description": "Persistent memory for AI agents. 64 MCP tools for remember, recall, rollback, audit, knowledge graph, context spaces, eval, cortex, replay, governed actions, and more. Works locally (SQLite, zero config) or with Novyx Cloud for teams.",
+    "tags": ["memory", "agents", "rollback", "audit", "knowledge-graph", "mcp", "ai-agents", "context-spaces"],
+    "title": "Novyx MCP",
+    "category": "programming"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## Novyx MCP

Persistent memory for AI agents with 64 MCP tools.

**What it does:** Remember, recall, rollback, audit, knowledge graph, context spaces, eval, cortex (autonomous maintenance), replay (time travel), governed actions, and more.

**Install:** `uvx novyx-mcp` or `pip install novyx-mcp`

**Works:** Locally with SQLite (zero config) or with Novyx Cloud for teams.

**Links:**
- PyPI: https://pypi.org/project/novyx-mcp/
- GitHub: https://github.com/novyxlabs/novyx-mcp
- Website: https://novyxlabs.com
- MCP Registry: Listed (AAA score on Glama)

## Summary by Sourcery

Add configuration file defining the Novyx MCP integration and its available tools.