### PR TITLE
feat: add Spotify MCP — full Spotify control (93 tools)

### DIFF
--- a/src/spotify-mcp.json
+++ b/src/spotify-mcp.json
@@ -1,0 +1,14 @@
+{
+  "author": "gupta-kush",
+  "createdAt": "2026-03-21",
+  "homepage": "https://github.com/gupta-kush/spotify-mcp",
+  "identifier": "spotify-mcp",
+  "meta": {
+    "avatar": "🎵",
+    "tags": ["spotify", "music", "playlists", "mcp", "ai-tools"],
+    "title": "Spotify MCP",
+    "description": "93-tool Spotify MCP server — playback control, playlist management, smart shuffle, natural language song search, vibe analysis, artist network mapping, and taste evolution tracking.",
+    "category": "tools"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
### Checklist

- [x] I have read the [README](../blob/main/README.md)
- [x] The description is written in English
- [x] `meta.json` and `plugin-template.json` are not modified
- [x] Plugin entry is placed inside `src/` folder and named as `<identifier>.json`

### Description

**Spotify MCP** is a Python/FastMCP MCP server providing 93 tools for complete Spotify integration.

**Capabilities:**
- **Playback** — play, pause, skip, seek, queue, volume, shuffle, repeat, transfer devices
- **Playlists** — create, edit, reorder, merge, diff, deduplicate, smart shuffle (6 strategies)
- **Search & Discovery** — natural language song search, artist network mapping, genre explorer
- **Library** — save/remove/check tracks, albums, shows, episodes
- **Analytics** — taste evolution, listening patterns, vibe analysis, playlist comparison
- **Social** — follow/unfollow artists and users

**Install:** `uvx spotify-mcp` or `pip install spotify-mcp`
**GitHub:** https://github.com/gupta-kush/spotify-mcp