### PR TITLE
feat: add Elecz energy signal MCP server

### DIFF
--- a/src/elecz.json
+++ b/src/elecz.json
@@ -1,0 +1,14 @@
+{
+  "author": "Sakari Korkia-Aho",
+  "name": "Elecz",
+  "description": "Real-time energy decision signals and spot prices for Finland (FI, SE, NO, DK). Optimized for AI agents and automated logistics.",
+  "identifier": "elecz-energy-signal",
+  "tags": ["energy", "home-automation", "finance", "logistics"],
+  "type": "mcp",
+  "mcpConfig": {
+    "name": "Elecz",
+    "url": "https://elecz-api.onrender.com"
+  },
+  "homepage": "https://elecz.com",
+  "avatar": "⚡"
+}


### PR DESCRIPTION
Added Elecz, a real-time energy signal MCP server for Nordic countries (FI, SE, NO, DK). Verified and running on Render.


- [ X] I have read the [`Readme.md`](https://github.com/lobehub/lobe-chat-plugins/)
- [ X] The description is written in English.
- [ X] The `meta.json` and `plugin-template.json` have not been modified.
- [X ] The `entry` is placed in the `src` directory with the `.json` file extension.
