### PR TITLE
feat: add Frihet ERP MCP server (52 tools, remote OAuth 2.0)

### DIFF
--- a/src/frihet-erp.json
+++ b/src/frihet-erp.json
@@ -1,0 +1,19 @@
+{
+  "author": "berthelius",
+  "createdAt": "2026-03-25",
+  "homepage": "https://frihet.io",
+  "identifier": "frihet-erp",
+  "type": "mcp",
+  "mcpConfig": {
+    "name": "Frihet ERP",
+    "url": "https://mcp.frihet.io"
+  },
+  "meta": {
+    "avatar": "💼",
+    "tags": ["erp", "invoicing", "accounting", "tax-compliance", "business-management", "open-banking", "e-invoicing"],
+    "title": "Frihet ERP",
+    "description": "AI-native ERP with 52 tools — invoicing, expenses, clients, products, quotes, accounting, tax compliance (VeriFactu, EN16931 e-invoicing), open banking (6,000+ banks). Remote server with OAuth 2.0. Works with Claude, Cursor, Windsurf, Cline.",
+    "category": "productivity"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## Plugin Info

- **Name:** Frihet ERP
- **Type:** Remote MCP Server (OAuth 2.0)
- **URL:** https://mcp.frihet.io
- **Homepage:** https://frihet.io
- **npm:** `@frihet/mcp-server` (v1.5.0)
- **GitHub:** https://github.com/Frihet-io/frihet-mcp
- **Docs:** https://docs.frihet.io
- **License:** MIT

## Description

Frihet ERP is an AI-native business management platform with 52 MCP tools covering:

- **Invoicing** — create, send, manage invoices with tax calculations
- **Expenses** — track and categorize business expenses
- **Clients & CRM** — full client management with health scoring
- **Products & catalog** — inventory and pricing management
- **Quotes** — generate and convert quotes to invoices
- **Accounting** — full double-entry GL, P&L, Balance Sheet, Trial Balance
- **Tax compliance** — VeriFactu (Spain), EU VAT, VIES validation, 365 fiscal positions across 123 countries
- **E-invoicing** — EN16931 standard, PEPPOL-ready
- **Open Banking** — Tink integration, 6,000+ banks across Europe
- **Reports** — Tax Period, Sales Tax Liability, AR Aging, and more

## Setup

Remote server — no local installation needed. Connect via OAuth 2.0:

```json
{
  "mcpServers": {
    "frihet": {
      "url": "https://mcp.frihet.io",
      "type": "streamable-http"
    }
  }
}
```

Compatible with Claude Desktop, Cursor, Windsurf, Cline, and any MCP-compatible client.

## Checklist

- [x] Plugin is functional and publicly accessible
- [x] Remote MCP server with OAuth 2.0 authentication
- [x] MIT licensed
- [x] Documentation available at https://docs.frihet.io
- [x] Entry follows the repository format (type: mcp, mcpConfig.url)
