### PR TITLE
Add ToolRouter — unified gateway to 150+ tools

### DIFF
--- a/src/toolrouter.json
+++ b/src/toolrouter.json
@@ -1,0 +1,15 @@
+{
+  "author": "Humanleap",
+  "createdAt": "2026-03-31",
+  "homepage": "https://toolrouter.com",
+  "identifier": "toolrouter",
+  "manifest": "https://api.toolrouter.com/mcp",
+  "meta": {
+    "avatar": "🔀",
+    "tags": ["mcp", "tools", "seo", "screenshots", "search", "aggregator"],
+    "title": "ToolRouter",
+    "description": "One gateway to 150+ tools for AI agents — SEO, screenshots, web search, image generation, video, security scanning, and more. One API key replaces managing dozens of provider accounts.",
+    "category": "tools"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
Adds ToolRouter plugin — a unified MCP gateway giving agents access to 150+ tools through one connection. One API key replaces managing dozens of separate provider accounts.

Includes SEO analysis, website screenshots, web search, image generation, video creation, security scanning, and more. Growing daily.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Remote MCP: https://api.toolrouter.com/mcp