### PR TITLE
Add crypto-quant-signal-mcp plugin

### DIFF
--- a/src/crypto-quant-signal-mcp.json
+++ b/src/crypto-quant-signal-mcp.json
@@ -1,0 +1,15 @@
+{
+  "author": "AlgoVault Labs",
+  "createdAt": "2025-06-01",
+  "homepage": "https://github.com/AlgoVaultLabs/crypto-quant-signal-mcp",
+  "identifier": "crypto-quant-signal-mcp",
+  "manifest": "https://raw.githubusercontent.com/AlgoVaultLabs/crypto-quant-signal-mcp/main/lobehub-manifest.json",
+  "meta": {
+    "avatar": "📊",
+    "description": "AI trading brain for crypto perps — composite BUY/SELL/HOLD signals, cross-venue funding rate arb scanning, and market regime detection for Hyperliquid perpetuals via MCP.",
+    "tags": ["trading", "crypto", "signals", "defi", "hyperliquid", "quant", "mcp"],
+    "title": "Crypto Quant Signal MCP",
+    "category": "stocks-finance"
+  },
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## Summary

- Adds **crypto-quant-signal-mcp** to the plugin index — an AI trading brain for crypto perpetuals
- Provides 3 tools via MCP: composite trade signals (`get_trade_signal`), cross-venue funding rate arb scanning (`scan_funding_arb`), and market regime detection (`get_market_regime`)
- Targets Hyperliquid perpetuals with cross-venue data from Binance and Bybit
- Live and functional at https://api.algovault.com/mcp
- Category: `stocks-finance`

## Plugin Details

| Field | Value |
|-------|-------|
| Author | AlgoVault Labs |
| Homepage | https://github.com/AlgoVaultLabs/crypto-quant-signal-mcp |
| Manifest | https://raw.githubusercontent.com/AlgoVaultLabs/crypto-quant-signal-mcp/main/lobehub-manifest.json |
| Category | stocks-finance |
| Tags | trading, crypto, signals, defi, hyperliquid, quant, mcp |

## Checklist

- [x] Plugin is live and functional
- [x] Manifest URL is accessible
- [x] JSON follows `plugin-template.json` format
- [x] Placed in `src/` directory
- [x] `schemaVersion: 1` included