### PR TITLE
feat: add ClawFetch MCP Server

### DIFF
--- a/src/clawfetch-mcp.json
+++ b/src/clawfetch-mcp.json
@@ -1,0 +1,17 @@
+{
+  "author": "clawfetch",
+  "identifier": "clawfetch-mcp",
+  "homepage": "https://clawfetch.ai",
+  "manifest": "https://mcp.clawfetch.ai/mcp",
+  "meta": {
+    "avatar": "\ud83e\udd9e",
+    "title": "ClawFetch MCP Server",
+    "description": "Fetch pages, render JS SPAs, perform deep multi-source research, and extract structured data from 17+ site types (GitHub, npm, PyPI, Twitter, YouTube, etc).",
+    "tags": [
+      "web-search",
+      "scraping",
+      "research",
+      "data-extraction"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds ClawFetch MCP Server to the LobeHub marketplace.

**ClawFetch** is an AI-powered web intelligence MCP server that:
- Fetches and renders pages (including JS SPAs)
- Performs deep multi-source research
- Extracts structured data from 17+ site types (GitHub, npm, PyPI, Twitter, YouTube, etc.)

**Server URL:** https://mcp.clawfetch.ai/mcp
**Homepage:** https://clawfetch.ai